### PR TITLE
Fix dependency entries

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,5 @@ reportlab>=3.6.12
 pymongo>=4.5.0
 passlib>=1.7.4
 cryptography>=41.0.0
-requests_aws4auth
-reportlab
 pandas>=2.0.0
 plotly>=5.13.0


### PR DESCRIPTION
## Summary
- drop duplicate `requests_aws4auth` and `reportlab` requirements
- ensure the `requirements.txt` file ends with a newline

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement streamlit>=1.31.0)*