### PR TITLE
Remove unused import in enterprise_rfp_assistant

### DIFF
--- a/enterprise_rfp_assistant.py
+++ b/enterprise_rfp_assistant.py
@@ -7,7 +7,6 @@ import uuid
 from typing import Dict, Any, List, Optional
 from openai import OpenAI
 import upload_pdf
-from rfp_filter import run_filter, SECTIONS
 import process_rfp
 import logging
 from datetime import datetime, timedelta


### PR DESCRIPTION
## Summary
- remove unused `run_filter` and `SECTIONS` import from `enterprise_rfp_assistant.py`

## Testing
- `python3 -m py_compile enterprise_rfp_assistant.py`
- `streamlit run enterprise_rfp_assistant.py` *(fails: command not found)*