### PR TITLE
Fix security issues and cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,6 +280,7 @@ The application is configured via environment variables:
 | `S3_BUCKET` | AWS S3 bucket name | Yes for S3 storage |
 | `AWS_REGION` | AWS region | Yes for AWS services |
 | `AWS_LAMBDA_URL` | URL for AWS Lambda function | Optional |
+| `ALLOWED_EMAIL_DOMAINS` | Comma-separated list of allowed email domains for registration | Optional |
 
 ### MongoDB Configuration
 

--- a/archive/rfp_analyzer/app/config.py
+++ b/archive/rfp_analyzer/app/config.py
@@ -19,7 +19,7 @@ AWS_ACCESS_KEY_ID = os.getenv("AWS_ACCESS_KEY_ID", "")
 AWS_SECRET_ACCESS_KEY = os.getenv("AWS_SECRET_ACCESS_KEY", "")
 AWS_REGION = os.getenv("AWS_REGION", "us-east-1")
 S3_BUCKET = os.getenv("S3_BUCKET", "my-rfp-bucket")
-LAMBDA_URL = os.getenv("LAMBDA_URL", "https://jc2qj7smmranhdtbxkazthh3hq0ymkih.lambda-url.us-east-1.on.aws/")
+LAMBDA_URL = os.getenv("LAMBDA_URL", "")
 
 # Application settings
 DEFAULT_MODEL = os.getenv("DEFAULT_MODEL", "gpt-4o")

--- a/archive/rfp_analyzer/requirements.txt
+++ b/archive/rfp_analyzer/requirements.txt
@@ -3,7 +3,6 @@ openai>=1.2.0
 boto3>=1.34.0
 requests>=2.31.0
 requests-aws4auth>=1.2.3
-PyPDF2>=3.0.1
 PyMuPDF>=1.22.5
 python-dotenv>=1.0.0
 beautifulsoup4>=4.12.0

--- a/enterprise_rfp_assistant.py
+++ b/enterprise_rfp_assistant.py
@@ -4,7 +4,7 @@ import uuid
 import streamlit as st
 from dotenv import load_dotenv
 
-from rfp_app.auth import load_svg_logo
+from rfp_app.logo_utils import load_svg_logo
 from rfp_app.storage import init_mongodb_auth
 from rfp_app.ui import get_colors, load_css, render_app_header, show_no_rfp_screen, display_rfp_data
 from rfp_app.chat import openai_api_key, debug_api_key, test_api_key, display_chat_interface
@@ -22,7 +22,10 @@ mongo_client, mongo_db, auth_instance, document_storage = init_mongodb_auth()
 
 # Load logo into session state
 if "logo_svg" not in st.session_state:
-    st.session_state.logo_svg = load_svg_logo()
+    try:
+        st.session_state.logo_svg = load_svg_logo()
+    except Exception:
+        st.session_state.logo_svg = ""
 
 # Basic session state defaults
 for key, default in {
@@ -93,7 +96,7 @@ def main_content():
         aws_region = "us-east-1"
         s3_bucket = "my-rfp-bucket"
         s3_key = ""
-        lambda_url = "https://jc2qj7smmranhdtbxkazthh3hq0ymkih.lambda-url.us-east-1.on.aws/"
+        lambda_url = os.getenv("AWS_LAMBDA_URL", "")
         selected_sections = ["all"]
         uploaded_file = st.file_uploader("", type=["pdf"], accept_multiple_files=False, key=f"uploader_{st.session_state.upload_id}")
         if uploaded_file and st.button("Process RFP", key="process_button"):

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,6 @@ openai>=1.2.0
 boto3>=1.34.0
 requests>=2.31.0
 requests-aws4auth>=1.2.3
-PyPDF2>=3.0.1
 PyMuPDF>=1.22.5
 python-dotenv>=1.0.0
 beautifulsoup4>=4.12.0

--- a/rfp_app/chat.py
+++ b/rfp_app/chat.py
@@ -20,11 +20,13 @@ openai_api_key = get_env_api_key()
 
 
 def debug_api_key(key: str, source: str) -> None:
-    if key:
-        masked = f"{key[:4]}...{key[-4:]}" if len(key) > 8 else "***"
-        print(f"DEBUG - API KEY from {source}: {masked}, Length: {len(key)}")
-    else:
-        print(f"DEBUG - API KEY from {source}: Not set or empty")
+    """Log masked API keys when DEBUG_API_KEY environment variable is true."""
+    if os.getenv("DEBUG_API_KEY", "").lower() == "true":
+        if key:
+            masked = f"{key[:4]}...{key[-4:]}" if len(key) > 8 else "***"
+            print(f"DEBUG - API KEY from {source}: {masked}, Length: {len(key)}")
+        else:
+            print(f"DEBUG - API KEY from {source}: Not set or empty")
 
 
 def get_openai_client() -> OpenAI:

--- a/rfp_app/logo_utils.py
+++ b/rfp_app/logo_utils.py
@@ -5,10 +5,14 @@ logger = logging.getLogger(__name__)
 
 
 def load_svg_logo(path: str = "rfp_analyzer_logo.svg"):
-    """Return SVG logo contents or None."""
+    """Return SVG logo contents.
+
+    Raises:
+        FileNotFoundError: If the logo file cannot be loaded.
+    """
     try:
         with open(path, "r") as logo_file:
             return logo_file.read()
     except Exception as e:
         logger.error(f"Error loading logo: {str(e)}")
-        return None
+        raise

--- a/upload_pdf.py
+++ b/upload_pdf.py
@@ -189,8 +189,8 @@ def main():
     parser.add_argument("--bucket", required=True, help="S3 bucket name")
     parser.add_argument("--key", help="S3 object key (defaults to filename)")
     parser.add_argument("--region", default="us-east-1", help="AWS region (default: us-east-1)")
-    parser.add_argument("--lambda-url", 
-                       default="https://jc2qj7smmranhdtbxkazthh3hq0ymkih.lambda-url.us-east-1.on.aws/",
+    parser.add_argument("--lambda-url",
+                       default=os.getenv("AWS_LAMBDA_URL", ""),
                        help="Lambda function URL")
     parser.add_argument("--sections", nargs='+', default=["all"], 
                        help="Sections to process (default: ['all'])")


### PR DESCRIPTION
## Summary
- rename `rfp_app/auth.py` to `logo_utils.py` and raise errors when logo loading fails
- hardcode-free Lambda URL via `AWS_LAMBDA_URL` env var
- gate API key debug logging behind `DEBUG_API_KEY` variable
- enhance `UserAuth` to check allowed domains and rate‑limit registration
- drop deprecated PyPDF2 requirement
- document `ALLOWED_EMAIL_DOMAINS` environment variable

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'boto3')*