### PR TITLE
Fix Lambda URL check

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,7 +279,7 @@ The application is configured via environment variables:
 | `ADMIN_PASSWORD` | Admin password | Yes |
 | `S3_BUCKET` | AWS S3 bucket name | Yes for S3 storage |
 | `AWS_REGION` | AWS region | Yes for AWS services |
-| `AWS_LAMBDA_URL` | URL for AWS Lambda function | Optional |
+| `AWS_LAMBDA_URL` | URL for AWS Lambda function (required for Lambda processing) | Optional |
 | `ALLOWED_EMAIL_DOMAINS` | Comma-separated list of allowed email domains for registration | Optional |
 
 ### MongoDB Configuration

--- a/rfp_app/pdf_processing.py
+++ b/rfp_app/pdf_processing.py
@@ -202,7 +202,7 @@ def process_uploaded_pdf(uploaded_file, aws_region: str, s3_bucket: str, s3_key:
             )
         except Exception as e:
             error_message = str(e)
-            if '502 Server Error: Bad Gateway' in error_message:
+            if '502 Server Error: Bad Gateway' in error_message or 'Lambda URL is not provided' in error_message:
                 st.markdown(
                     "<div class=\"alert alert-warning\"><strong>⚠️ Lambda Gateway Error - Using Local Fallback</strong><br>Cannot connect to the AWS Lambda function. Switching to local processing.</div>",
                     unsafe_allow_html=True,

--- a/upload_pdf.py
+++ b/upload_pdf.py
@@ -165,6 +165,11 @@ def upload_and_process_pdf(
         Exception: If upload or processing fails
     """
     logger.info(f"Starting upload and process for {pdf_path}")
+
+    if not lambda_url:
+        raise ValueError(
+            "Lambda URL is not provided. Set the AWS_LAMBDA_URL environment variable or pass --lambda-url"
+        )
     
     # Upload to S3
     if not upload_to_s3(pdf_path, s3_bucket, s3_key, aws_region):
@@ -191,7 +196,7 @@ def main():
     parser.add_argument("--region", default="us-east-1", help="AWS region (default: us-east-1)")
     parser.add_argument("--lambda-url",
                        default=os.getenv("AWS_LAMBDA_URL", ""),
-                       help="Lambda function URL")
+                       help="Lambda function URL. Required for AWS processing")
     parser.add_argument("--sections", nargs='+', default=["all"], 
                        help="Sections to process (default: ['all'])")
     


### PR DESCRIPTION
## Summary
- error out if AWS Lambda URL isn't set to avoid invalid requests
- fallback to local PDF processing when Lambda URL is missing
- document that AWS_LAMBDA_URL is needed for Lambda processing

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'boto3')*